### PR TITLE
1079-remember-activated-state-as-long-as-a-user-stays-on-website-in-tab

### DIFF
--- a/src/content/components/Activate.tsx
+++ b/src/content/components/Activate.tsx
@@ -24,12 +24,14 @@ const activateButtonStyle: CSS.Properties = {
 
 interface ActivateProps {
   activeDomain: ActiveDomain;
+  isCashbackActivatedAlready: boolean;
   getVanity: () => Promise<Vanity | undefined>;
   showError: () => void;
 }
 
 const Activate: FC<ActivateProps> = ({
   activeDomain,
+  isCashbackActivatedAlready,
   getVanity,
   showError,
 }) => {
@@ -44,6 +46,13 @@ const Activate: FC<ActivateProps> = ({
     }
   }, [activeDomain]);
 
+  useEffect(() => {
+    // set isActive automatically if domain is the the same with the last stored domain
+    if (isCashbackActivatedAlready && !isActive) {
+      setIsActive(true);
+    }
+  }, [activeDomain.Domain, isCashbackActivatedAlready, isActive]);
+
   const activate = async (): Promise<void> => {
     setIsLoading(true);
     const vanity = await getVanity();
@@ -52,6 +61,7 @@ const Activate: FC<ActivateProps> = ({
         status: ACTIVATE_CASHBACK,
         payload: {
           url: vanity.VanityURL,
+          domain: activeDomain.Domain,
         },
       } as ExtensionMessage<typeof ACTIVATE_CASHBACK>)) as BackgroundResponseMessage<
         typeof ACTIVATE_CASHBACK

--- a/src/content/pages/Eligible.tsx
+++ b/src/content/pages/Eligible.tsx
@@ -62,10 +62,12 @@ const Eligible: FC<EligibleProps> = ({ eligibleDomain, showError }) => {
     }
   };
 
-  // reset vanity if eligible domain original url changes
+  // reset vanity if eligible domain original url changes and domain is different
   useEffect(() => {
-    setVanity(undefined);
-  }, [eligibleDomain.originalUrl]);
+    if (!eligibleDomain.isCashbackActivatedAlready) {
+      setVanity(undefined);
+    }
+  }, [eligibleDomain]);
 
   return (
     <div style={style}>
@@ -74,6 +76,7 @@ const Eligible: FC<EligibleProps> = ({ eligibleDomain, showError }) => {
         <Activate
           getVanity={getVanity}
           activeDomain={eligibleDomain.activeDomain}
+          isCashbackActivatedAlready={eligibleDomain.isCashbackActivatedAlready}
           showError={showError}
         />
         <div style={orStyle}>or</div>

--- a/src/helpers/activeDomain.ts
+++ b/src/helpers/activeDomain.ts
@@ -1,7 +1,5 @@
 import { ActiveDomain } from 'wildlink-js-client';
 
-export const REMEMBERED_DOMAINS = 'REMEMBERED_DOMAINS';
-
 export const rememberedDomains: {
   [key: string]: string;
 } = {};

--- a/src/helpers/activeDomain.ts
+++ b/src/helpers/activeDomain.ts
@@ -1,5 +1,11 @@
 import { ActiveDomain } from 'wildlink-js-client';
 
+export const REMEMBERED_DOMAINS = 'REMEMBERED_DOMAINS';
+
+export const rememberedDomains: {
+  [key: string]: string;
+} = {};
+
 export const parseActiveDomainMaxRate = (
   commissionRate: NonNullable<ActiveDomain['Merchant']['MaxRate']>,
 ): string => {
@@ -9,18 +15,47 @@ export const parseActiveDomainMaxRate = (
   }
 
   if (commissionRate.Kind === 'PERCENTAGE') {
-    return `${amount.toLocaleString(undefined, {
+    return `${amount.toLocaleString('en-US', {
       minimumFractionDigits: 0,
       maximumFractionDigits: 1,
     })}%`;
   }
 
   if (commissionRate.Kind === 'FLAT') {
-    return amount.toLocaleString(undefined, {
+    return amount.toLocaleString('en-US', {
       style: 'currency',
       currency: commissionRate.Currency,
     });
   }
 
   return '';
+};
+
+export const rememberTabAndDomain = (
+  domain: string,
+  tabId: number | undefined,
+): void => {
+  // do nothing if tab ID is undefined
+  if (!tabId) {
+    return;
+  }
+
+  rememberedDomains[`${tabId}`] = domain;
+};
+
+export const removeRememberedTabAndDomain = (
+  tabId: number | undefined,
+): void => {
+  // do nothing if tab ID is undefined
+  if (!tabId) {
+    return;
+  }
+
+  delete rememberedDomains[`${tabId}`];
+};
+
+export const isCashbackActivated = (domain: string): boolean => {
+  return !!Object.values(rememberedDomains).find(
+    (rememberedDomain) => rememberedDomain === domain,
+  );
 };

--- a/src/helpers/browser/message.ts
+++ b/src/helpers/browser/message.ts
@@ -21,6 +21,7 @@ export const PONG = 'PONG';
 
 interface NewTab {
   url: string;
+  domain: string;
 }
 
 type PayloadMap = {

--- a/src/helpers/browser/message.ts
+++ b/src/helpers/browser/message.ts
@@ -1,4 +1,4 @@
-import { Device, Vanity } from 'wildlink-js-client';
+import { ActiveDomain, Device, Vanity } from 'wildlink-js-client';
 
 import { EligibleDomain } from '/wildlink/helpers/domain';
 
@@ -21,7 +21,7 @@ export const PONG = 'PONG';
 
 interface NewTab {
   url: string;
-  domain: string;
+  domain: ActiveDomain['Domain'];
 }
 
 type PayloadMap = {

--- a/src/helpers/browser/tab.test.ts
+++ b/src/helpers/browser/tab.test.ts
@@ -75,6 +75,7 @@ describe('evaluate whether or not a tab is eligible', () => {
       payload: {
         activeDomain: exampleActiveDomain,
         originalUrl: tabUrl,
+        isCashbackActivatedAlready: false,
       },
     });
     expect(mockSendMessage).toHaveBeenLastCalledWith(tabId, {
@@ -93,6 +94,7 @@ describe('evaluate whether or not a tab is eligible', () => {
       payload: {
         activeDomain: exampleActiveDomain,
         originalUrl: tabUrl,
+        isCashbackActivatedAlready: false,
       },
     });
     expect(mockSendMessage).toBeCalledTimes(1);

--- a/src/wildlink/helpers/domain.ts
+++ b/src/wildlink/helpers/domain.ts
@@ -6,6 +6,7 @@ import api from '/helpers/api';
 export interface EligibleDomain {
   activeDomain: ActiveDomain;
   originalUrl: string;
+  isCashbackActivatedAlready: boolean;
 }
 
 export const parseDomain = (url: string): string[] => {


### PR DESCRIPTION
Remember activated state for activated cashback while on the same domain, cashback keeps being activated while at least one tab of the same domain is open(remembering domains in memory without extension storage)